### PR TITLE
view team fixed

### DIFF
--- a/components/GameCard.js
+++ b/components/GameCard.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import Button from 'react-bootstrap/Button';
 import Card from 'react-bootstrap/Card';
-import Link from 'next/link';
 import { deleteGame } from '../api/gameData';
 
 function GameCard({ gameObj, onUpdate }) {
@@ -20,9 +19,6 @@ function GameCard({ gameObj, onUpdate }) {
         <Card.Text>Team 1: {gameObj.teams[0]?.name}</Card.Text>
         <Card.Text>Team 2: {gameObj.teams[1]?.name}</Card.Text>
 
-        <Link href={`/game/edit/${gameObj.id}`} passHref>
-          <Button variant="info">ADD WINNER</Button>
-        </Link>
         <Button variant="danger" onClick={deleteThisGame} className="m-2">
           DELETE
         </Button>
@@ -39,7 +35,6 @@ GameCard.propTypes = {
     teamId: PropTypes.string,
     teams: PropTypes.arrayOf(PropTypes.string),
     id: PropTypes.string,
-    winningTeamId: PropTypes.number,
   }).isRequired,
   onUpdate: PropTypes.func.isRequired,
 };

--- a/components/TeamCard.js
+++ b/components/TeamCard.js
@@ -19,7 +19,7 @@ function TeamCard({ teamObj, onUpdate }) {
 
   useEffect(() => {
     captain();
-  });
+  }, []);
 
   return (
     <Card style={{ width: '18rem', margin: '10px' }}>

--- a/components/forms/GameForm.js
+++ b/components/forms/GameForm.js
@@ -12,7 +12,6 @@ const initialState = {
   createdAt: '',
   teamOneId: '',
   teamTwoId: '',
-  winningTeam: '',
 };
 export default function GameForm({ gameObj }) {
   const { user } = useAuth();
@@ -42,7 +41,6 @@ export default function GameForm({ gameObj }) {
       const payload = {
         name: formInput.name,
         createdAt: formInput.createdAt,
-        winningTeamId: '',
         teams: [formInput.teamOneId, formInput.teamTwoId],
       };
       createGame(payload).then((game) => {
@@ -109,19 +107,7 @@ export default function GameForm({ gameObj }) {
           }
           </Form.Select>
         </Form.Group>
-        <Form.Select
-          type="text"
-          placeholder="Enter Team Name"
-          name="winningTeam"
-          value={formInput.winningTeam}
-          onChange={handleChange}
-          required
-        >
-          <option value="">Winning Team</option>
-          <option>teamOne</option>
-          <option>teamTwo</option>
 
-        </Form.Select>
         <Form.Group className="mb-3">
           <Form.Label>Game Name</Form.Label>
           <Form.Control
@@ -146,7 +132,7 @@ GameForm.propTypes = {
     name: PropTypes.string,
     teams: PropTypes.arrayOf(PropTypes.number),
     id: PropTypes.string,
-    // createdAt: PropTypes.instanceOf(Date),
+    createdAt: PropTypes.instanceOf(Date),
     // winningTeamId: PropTypes.string,
   }),
 };

--- a/components/forms/PlayerForm.js
+++ b/components/forms/PlayerForm.js
@@ -39,13 +39,13 @@ function PlayerForm({ obj }) {
   const handleSubmit = (e) => {
     e.preventDefault();
     if (obj.id) {
-      updatePlayers(formInput).then(() => router.back());
+      updatePlayers(formInput).then(() => router.push(`/player/${obj.id}`));
     } else {
       const payload = { ...formInput, volunteerId: user.uid };
       createPlayer(payload).then(({ name }) => {
         const patchPayload = { id: name };
         updatePlayers(patchPayload).then(() => {
-          router.back();
+          router.push('/players');
         });
       });
     }

--- a/pages/player/[id].js
+++ b/pages/player/[id].js
@@ -34,18 +34,18 @@ function ViewPlayer() {
 
   useEffect(() => {
     getSingleTeam(playerDetails.teamId).then(setTeam);
-  }, []);
+  }, [id]);
 
   return (
     <div>
       <div className="teamView">
         <Card style={{ width: '400px', margin: '10px' }}>
           <Card.Body>
-            <Card.Title className="teamTitle">{playerDetails.name}{playerDetails.isCaptain && <span style={{ color: '#fafafa' }}>⚽</span>}</Card.Title>
+            <Card.Title className="teamTitle">{playerDetails.firstName} {playerDetails.lastName}{playerDetails.isCaptain && <span style={{ color: '#fafafa' }}>⚽</span>}</Card.Title>
             <Card.Img variant="top" src={playerDetails.image} alt={playerDetails.name} style={{ width: '350px' }} />
             <h5>{playerDetails.first_name} {playerDetails.last_name}</h5>
             <h6>Position: {playerDetails.position}</h6>
-            <Card.Text>{team.name}</Card.Text>
+            <Card.Text>Team: {team.name}</Card.Text>
             <Link href={`/player/edit/${playerDetails.id}`} passHref>
               <Button className="editBtn m-2" variant="dark">EDIT</Button>
             </Link>


### PR DESCRIPTION
The game card has the option to be deleted, and we took off the 'winner' button. The view player card has the correct path and also the team shows on the card. 

## Description
The game card has the option to be deleted, and we took off the 'winner' button. The view player card has the correct path and also the team shows on the card. 



## Motivation and Context
The game card needs to show the schedule only, and not the winner as it doesn't make sense on this page. The view player card should have the team name displayed.

## How Can This Be Tested?
Edit a player and the team will update. View games from the NavBar and you will see the list of schedules.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)