### PR TITLE
fixed game bug

### DIFF
--- a/pages/games.js
+++ b/pages/games.js
@@ -1,15 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import { useAuth } from '../utils/context/authContext';
+// import { useAuth } from '../utils/context/authContext';
 import { getGames } from '../api/gameData';
 import GameCard from '../components/GameCard';
 
 function ShowGames() {
   const [gameDetails, setGameDetails] = useState([]);
 
-  const { user } = useAuth();
+  // const { user } = useAuth();
 
   const getAllGames = () => {
-    getGames(user.uid).then(setGameDetails);
+    getGames().then(setGameDetails);
   };
 
   useEffect(() => {


### PR DESCRIPTION
The getAllGames() api call does not need to take a parameter. Before, we passed in user.uid, but  we had to refresh the page everytime a game was created in order to see the team names. Now, the page renders instantly.
![image](https://github.com/nss-evening-cohort-24/volunteer-match2/assets/119310701/2dbde161-e5eb-490b-928a-c7b8702fc397)
